### PR TITLE
ENH, added options for demeaning and standardising reference and data…

### DIFF
--- a/ft_denoise_tsr.m
+++ b/ft_denoise_tsr.m
@@ -315,10 +315,13 @@ else
 
 end
 
-% unzscore the data
+% Unstandardise the data/refchannels and test data/rechannels
 if istrue(cfg.standardiserefdata)
-  std_refdata   = repmat(std_refdata, numel(cfg.reflags), 1);
-  refdata.trial = cellvecmult(refdata.trial, std_refdata);
+  std_refdata       = repmat(std_refdata, numel(cfg.reflags), 1);
+  refdata.trial     = cellvecmult(refdata.trial, std_refdata);
+  if usetestdata
+    testrefdata.trial = cellvecmult(testrefdata.trial, std_refdata(1)); % no timelag dimension here, STD is scalar 
+  end
   if exist('beta_data', 'var')
     beta_ref  = beta_ref*diag(std_refdata);
   else
@@ -327,7 +330,10 @@ if istrue(cfg.standardiserefdata)
 end
 
 if istrue(cfg.standardisedata)
-data.trial    = cellvecmult(data.trial, std_data);
+data.trial     = cellvecmult(data.trial, std_data);
+if usetestdata
+    testdata.trial = cellvecmult(testdata.trial, std_data); % use STD estimated on the training data
+end
   if exist('beta_data', 'var')
     beta_data = diag(std_data)*beta_data;
   end

--- a/ft_denoise_tsr.m
+++ b/ft_denoise_tsr.m
@@ -360,19 +360,6 @@ if usetestdata
   refdata = ft_selectdata(tmpcfg, refdata);
   [~,refdata] = rollback_provenance(cfg, refdata);
 
-  fprintf('demeaning the testdata\n');
-  % demean
-  if istrue(cfg.demeanrefdata) % make it contigent on refdata demeaning
-    fprintf('demeaning test reference channels\n');
-    mu_testrefdata    = cellmean(testrefdata.trial, 2);
-    testrefdata.trial = cellvecadd(testrefdata.trial, -mu_testrefdata);
-  end
-  if istrue(cfg.demeandata) % make it contigent on data demeaning
-    fprintf('demeaning test data channels\n');
-    mu_testdata    = cellmean(testdata.trial, 2);
-    testdata.trial = cellvecadd(testdata.trial, -mu_testdata);
-  end
-
   dataout   = keepfields(testdata, {'cfg' 'label' 'time' 'grad' 'elec' 'opto' 'trialinfo' 'fsample'});
   predicted = beta_ref*testrefdata.trial;
   
@@ -413,7 +400,7 @@ else
   switch cfg.performance    
     case 'Pearson'
       for i = 1:size(data.trial{1}, 1)
-        dataout.pearson(i, 1) = corr(data.trial{1}(i, :)', predicted{1}(i,:)', 'type', 'Pearson', 'rows', 'pairwise'); 
+        dataout.performance(i, 1) = corr(data.trial{1}(i, :)', predicted{1}(i,:)', 'type', 'Pearson', 'rows', 'pairwise'); 
       end
     case 'r-squared'
       


### PR DESCRIPTION
… channels separately, included cfg.performance option, added some incomplete doc

@schoffelen This PR in branch trf-corr implements what was discussed yesterday. These options are created: `cfg.demeanrefdata, cfg.demeandata, cfg.standardisedata, cfg.stadardiserefdata`  (all defaulted to 'no') and `cfg.performance` (defaulted to 'Pearson'). The latter option might not be the intended feature of this function, so it is not documented in the visible part. It would keep this option in for now, though.

It runs OK syntactically with my code. Perhaps throw and extra pair of eyes on l. 318-335 ('unzscoring') and l.358-398 ('demeaning test data' --> which is conditioned on demeaning data flags).